### PR TITLE
サイドバーに最新のメッセージを表示する

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,16 @@ class Group < ApplicationRecord
   has_many :users, through: :group_users
   has_many :messages
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      if last_message.content?
+        last_message.content
+      else
+        "画像が投稿されています"
+      end
+    else
+      "まだメッセージはありません"
+    end
+  end
 end

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -17,4 +17,4 @@
           %p.group__group-name
             = group.name
           %p.group__latest-message
-            まだメッセージはありません
+            = group.show_last_message


### PR DESCRIPTION
# What
chat-spaceのサイドバーに最新メッセージを表示します。画像が登録されている時やメッセージがない時、状況に応じて表示します。
# Why
最新のメッセージを表示することによってひと目でどのグループに更新があったかわかる為。
